### PR TITLE
fix: Add permissions for GitHub Actions in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,10 @@ on:
   release:
     types: [published]
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Updated the publish.yml workflow to include permissions for writing id-token and reading contents, enhancing security and functionality during the release process.